### PR TITLE
feat: add "semantic commit message" to CI section

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -17,3 +17,5 @@
 - Deploy a merge to master into an environment (whether ephemeral or static) to perform a light end-to-end, not repeating the above steps
 - Perform quick end-to-end tests that are there to just validate that things work together as expected, (no need to repeat unit / acceptance tests already done)
 - Drive common tasks from a Makefile to provide a common interface across projects and languages (e.g. build, start, test, etc)
+- Have clear, concise commit messages conforming to [semantic commit messages](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#), and using the footer to add bug tracker/story ID and/or username(s) if developed in a pair/mob (`git commit --verbose` is useful for multi-line messages)
+


### PR DESCRIPTION
Have used [semantic commit message](https://seesparkbox.com/foundry/semantic_commit_messages) as inspired by Angular/Karma before. Keeps commit message quality high, makes generating changelogs trivial ([libs](https://github.com/conventional-changelog/standard-version) available).

More details [here](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#) and [here](https://github.com/conventional-changelog/conventional-changelog-angular/blob/master/convention.md).

Some thoughts on [squashing commits](https://github.com/conventional-changelog/standard-version#should-i-always-squash-commits-when-merging-prs) that I agree with, but not sure if it's worth formalising for all cases.

Could also add [guidance on commit messages](http://chris.beams.io/posts/git-commit/) if it's not too rigid - imperative mood is the only one that really affects changelog parsing IMHO
