### PR TITLE
feat: add container label schema to configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and raise a PR for this to be amended.
 * [Monitoring and Metrics](docs/monitoring_metrics.md)
 * [Logging](docs/logging.md)
 * [Service Discovery](docs/service_discovery.md)
+* [Containerisation](docs/containerisation.md)
 * [Continuous Integration](docs/ci.md)
 * [Continuous_Deployment](docs/cd.md)
 * [Security](docs/security.md)

--- a/docs/containerisation.md
+++ b/docs/containerisation.md
@@ -1,0 +1,7 @@
+## Containerisation
+
+### As a service:
+
+* I will adhere to [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/)
+* I will use [Docker/rkt label schema](http://label-schema.org/rc1/) where applicable to define the contents and usage of an image 
+


### PR DESCRIPTION
This is an emerging standard pioneered by ex-Gov.uk's @garethr (still RC1) but still provides value at this stage.

Of particular interest are the invocation examples under the `org.label-schema.docker.cmd` namespace, e.g. 

```
org.label-schema.docker.cmd= "docker run -d -p 5000:5000 -v config.json:/etc/config.json myapp" 
org.label-schema.docker.cmd.devel = "docker run -d -p 5050:5050 -e ENV=DEV myapp"   
org.label-schema.docker.cmd.test = "docker run myapp runtests"  
org.label-schema.docker.debug-shell = "docker exec -it $CONTAINER /bin/redis-cli"   
```

For example from [here](https://puppet.com/blog/building-agreement-around-docker-labels): 

```
LABEL org.label-schema.vendor="Puppet" \
  org.label-schema.url="https://github.com/puppetlabs/puppetserver" \
  org.label-schema.name="Puppet Server" \
  org.label-schema.version="2.6.0" \
  org.label-schema.vcs-url="github.com:puppetlabs/puppetserver.git" \
  org.label-schema.vcs-ref="ebd57d487d209bf575fcce26335c8f3e0ad09288" \
  org.label-schema.build-date="2016-09-8T23:20:50.52Z" \
  org.label-schema.docker.schema-version="1.0"
```
