### PR TITLE
Link to metrics on performance page no longer 404s

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,9 +1,10 @@
 ## Performance
 
-### As a Service, I should: 
+### As a Service, I should:
+
 - Always have a baseline set of metrics of my isolated service
 - Understand what those metrics need to be for each functionality i.e. how long file uploads should take vs a generic GET request
 - Make sure the baseline does not include any other components i.e. networks, infrastructure etc.
-- Expose a set of metrics, see [Metrics](github.com/ukhomeoffice/monitoring_metrics.md)
+- Expose a set of metrics, see [Metrics](monitoring_metrics.md)
 - Make performance testing part of my Continuous Integration workflow
 - Have a history of performance over time


### PR DESCRIPTION
The metrics link was a 404 on the performance page. I have fixed this.
