### PR TITLE
merge into master at least daily for CI conformance

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -17,3 +17,4 @@
 - Deploy a merge to master into an environment (whether ephemeral or static) to perform a light end-to-end, not repeating the above steps
 - Perform quick end-to-end tests that are there to just validate that things work together as expected, (no need to repeat unit / acceptance tests already done)
 - Drive common tasks from a Makefile to provide a common interface across projects and languages (e.g. build, start, test, etc)
+- Merge my branch into master at least once a day


### PR DESCRIPTION
For CI it is important to prevent long running branches. Should we not encourage people to merge their branch into master at least once a day?
